### PR TITLE
Fix layer pointer usage and enable warning-free build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OBJECTS = $(SOURCES:.c=.o)
 
 # Règle principale : crée l'exécutable
 $(TARGET): $(OBJECTS)
-	$(CC) $(OBJECTS) -o $(TARGET)
+	$(CC) $(OBJECTS) -o $(TARGET) -lm
 
 # Règle générique : compile chaque .c en .o
 %.o: %.c

--- a/layers/layers.c
+++ b/layers/layers.c
@@ -9,7 +9,7 @@ float generate_random_float(int min, int max) {
 }
 
 
-Layer init_layer(int input_size, int size, char act_function[30]) {
+Layer init_layer(int input_size, int size, const char* act_function) {
 
     Layer layer;
 

--- a/layers/layers.h
+++ b/layers/layers.h
@@ -3,7 +3,7 @@
 
 #include "type.h"
 
-Layer init_layer(int input_size, int size, char act_function[30]);
+Layer init_layer(int input_size, int size, const char* act_function);
 
 void free_layer(Layer* layer);
 

--- a/mlp/mlp.c
+++ b/mlp/mlp.c
@@ -44,7 +44,7 @@ int print_mlp_specs(NeuralNetwork mlp) {
     int memory_used = 0;
     for(int layer_index = 0; layer_index < mlp.num_layers; layer_index++) {
 
-        LayerInfo layer_info = calcul_layer_info(mlp.layers[layer_index]);
+        LayerInfo layer_info = calcul_layer_info(&mlp.layers[layer_index]);
 
         number_of_weights += layer_info.num_weights;
         number_of_neurons += layer_info.num_neurons;
@@ -62,7 +62,7 @@ float* forward_network(const NeuralNetwork* mlp, const float* inputs) {
     float* output = NULL;
 
     for (int i = 0; i < mlp->num_layers; ++i) {
-        output = forward_layer(mlp->layers[i], current_input);
+        output = forward_layer(&mlp->layers[i], current_input);
         if (!output) {
             if (current_input != inputs) {
                 free((void*)current_input);
@@ -78,5 +78,5 @@ float* forward_network(const NeuralNetwork* mlp, const float* inputs) {
 }
 
 void backward_network(const NeuralNetwork* mlp) {
-    
+    (void)mlp;
 }


### PR DESCRIPTION
## Summary
- pass layer addresses when calling `calcul_layer_info` and `forward_layer`
- update `init_layer` to accept `const char*` and mark the unused backprop argument
- link against libm during the build so `expf` resolves

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68ceb0e13cb48323901d8e30aafdcfad