### PR TITLE
Handle allocation failures in neural network layers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OBJECTS = $(SOURCES:.c=.o)
 
 # Règle principale : crée l'exécutable
 $(TARGET): $(OBJECTS)
-	$(CC) $(OBJECTS) -o $(TARGET)
+	$(CC) $(OBJECTS) -lm -o $(TARGET)
 
 # Règle générique : compile chaque .c en .o
 %.o: %.c

--- a/layers/layers.c
+++ b/layers/layers.c
@@ -11,17 +11,27 @@ float generate_random_float(int min, int max) {
 
 Layer init_layer(int input_size, int size, char act_function[30]) {
 
-    Layer layer;
+    Layer layer = (Layer){0};
 
-    snprintf(layer.act_function, sizeof(layer.act_function),"%s", act_function);
-    
+    snprintf(layer.act_function, sizeof(layer.act_function), "%s", act_function);
+
     layer.neuron_number = size;
     layer.input_size = input_size;
     layer.weights = malloc(layer.neuron_number * layer.input_size * sizeof(float));
+    if (layer.weights == NULL) {
+        fprintf(stderr, "Failed to allocate memory for layer weights.\n");
+        layer.neuron_number = 0;
+        layer.input_size = 0;
+        return layer;
+    }
     layer.bias = malloc(layer.neuron_number * sizeof(float));
-
-    if(layer.weights == NULL) {
-        printf("MALLOC ALLOCATION FAILED");
+    if (layer.bias == NULL) {
+        fprintf(stderr, "Failed to allocate memory for layer bias.\n");
+        free(layer.weights);
+        layer.weights = NULL;
+        layer.neuron_number = 0;
+        layer.input_size = 0;
+        return layer;
     }
 
 
@@ -38,7 +48,7 @@ Layer init_layer(int input_size, int size, char act_function[30]) {
         }
     };
 
-    
+
     return layer;
 };
 
@@ -75,6 +85,9 @@ int print_layer_specs(const Layer* layer) {
 
 float* forward_layer(const Layer* layer, const float* inputs) {
     float* outputs = malloc(layer->neuron_number * sizeof(float));
+    if (outputs == NULL) {
+        return NULL;
+    }
     
     for(int neuron_index = 0; neuron_index < layer->neuron_number; neuron_index++) {
         float sum = layer->bias[neuron_index];

--- a/main.c
+++ b/main.c
@@ -26,6 +26,10 @@ int main() {
     float real[5] = {1,2,3,4,5}; 
 
     NeuralNetwork mlp = init_neural_network(1,5,neurons_for_each_layers, 6);
+    if (mlp.layers == NULL) {
+        fprintf(stderr, "Failed to initialize neural network.\n");
+        return EXIT_FAILURE;
+    }
     float input = 1.0f;
     float *result = forward_network(&mlp, &input);
 
@@ -36,6 +40,8 @@ int main() {
         printf("%f ",result[result_index]);
       }
       printf("\n");
+    } else {
+      fprintf(stderr, "Failed to compute network outputs.\n");
     }
     free_neural_network(&mlp);
     float loss = 0.0f;

--- a/mlp/mlp.c
+++ b/mlp/mlp.c
@@ -5,20 +5,48 @@
 
 
 NeuralNetwork init_neural_network(int input_size, int output_size, int neuron_for_each_layers[], int number_of_layer) {
-    NeuralNetwork mlp;
+    NeuralNetwork mlp = (NeuralNetwork){0};
 
     int hidden_layers = number_of_layer;
-    mlp.num_layers = hidden_layers + 1; 
+    mlp.num_layers = hidden_layers + 1;
     mlp.layers = malloc(mlp.num_layers * sizeof(Layer));
+    if (mlp.layers == NULL) {
+        fprintf(stderr, "Failed to allocate memory for neural network layers.\n");
+        mlp.num_layers = 0;
+        return mlp;
+    }
+
     mlp.output_size = output_size;
     int latest_input_size = input_size;
 
     for (int i = 0; i < hidden_layers; i++) {
         mlp.layers[i] = init_layer(latest_input_size, neuron_for_each_layers[i], "sigmoid");
+        if (mlp.layers[i].weights == NULL || mlp.layers[i].bias == NULL) {
+            fprintf(stderr, "Failed to initialize hidden layer %d.\n", i);
+            for (int j = 0; j < i; ++j) {
+                free_layer(&mlp.layers[j]);
+            }
+            free(mlp.layers);
+            mlp.layers = NULL;
+            mlp.num_layers = 0;
+            mlp.output_size = 0;
+            return mlp;
+        }
         latest_input_size = neuron_for_each_layers[i];
     }
 
     mlp.layers[hidden_layers] = init_layer(latest_input_size, output_size, "sigmoid");
+    if (mlp.layers[hidden_layers].weights == NULL || mlp.layers[hidden_layers].bias == NULL) {
+        fprintf(stderr, "Failed to initialize output layer.\n");
+        for (int j = 0; j < hidden_layers; ++j) {
+            free_layer(&mlp.layers[j]);
+        }
+        free(mlp.layers);
+        mlp.layers = NULL;
+        mlp.num_layers = 0;
+        mlp.output_size = 0;
+        return mlp;
+    }
 
     return mlp;
 }
@@ -44,7 +72,7 @@ int print_mlp_specs(NeuralNetwork mlp) {
     int memory_used = 0;
     for(int layer_index = 0; layer_index < mlp.num_layers; layer_index++) {
 
-        LayerInfo layer_info = calcul_layer_info(mlp.layers[layer_index]);
+        LayerInfo layer_info = calcul_layer_info(&mlp.layers[layer_index]);
 
         number_of_weights += layer_info.num_weights;
         number_of_neurons += layer_info.num_neurons;
@@ -58,11 +86,14 @@ int print_mlp_specs(NeuralNetwork mlp) {
     return 1;
 }
 float* forward_network(const NeuralNetwork* mlp, const float* inputs) {
-    const float* current_input = inputs;   
+    if (mlp == NULL || mlp->layers == NULL || mlp->num_layers <= 0) {
+        return NULL;
+    }
+    const float* current_input = inputs;
     float* output = NULL;
 
     for (int i = 0; i < mlp->num_layers; ++i) {
-        output = forward_layer(mlp->layers[i], current_input);
+        output = forward_layer(&mlp->layers[i], current_input);
         if (!output) {
             if (current_input != inputs) {
                 free((void*)current_input);


### PR DESCRIPTION
## Summary
- validate allocations in `init_layer` and `forward_layer`, returning safe data when memory allocation fails
- propagate allocation errors through neural network initialization/forwarding and handle failures in `main`
- link against the math library so builds resolve `expf`

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68ceb0e307c88323b0c436e69f412170